### PR TITLE
Fix malformated authorized_keys

### DIFF
--- a/files/create-sftp-user
+++ b/files/create-sftp-user
@@ -87,7 +87,7 @@ if [ -d "$userKeysQueuedDir" ]; then
     userKeysAllowedFile="/home/$user/.ssh/authorized_keys"
 
     for publickey in "$userKeysQueuedDir"/*; do
-        cat "$publickey" >> "$userKeysAllowedFileTmp"
+        echo "$publickey" >> "$userKeysAllowedFileTmp"
     done
 
     # Remove duplicate keys


### PR DESCRIPTION
If there are multiple public key files in the .ssh/keys directory and the
files does not end with a new line the resulting authorized_keys file
will be malformed.

Using echo instead of cat should make sure that we always add a
new line between entries.

Solves: atmoz#161